### PR TITLE
Switch embedding model to CodeRankEmbed

### DIFF
--- a/broom/embeddings.py
+++ b/broom/embeddings.py
@@ -12,10 +12,7 @@ from langchain_core.embeddings import Embeddings
 class CodeEmbedder:
     """Class for generating embeddings from code."""
 
-    def __init__(
-        self,
-        model_name: str = "Salesforce/SFR-Embedding-Code-400M_R"
-    ):
+    def __init__(self, model_name: str = "nomic-ai/CodeRankEmbed"):
         """Initialize the code embedder.
 
         Args:
@@ -23,16 +20,13 @@ class CodeEmbedder:
         """
         self.model: Embeddings = HuggingFaceEmbeddings(
             model_name=model_name,
-            model_kwargs={
-                "device": "cpu",
-                "trust_remote_code": True
-            },
+            model_kwargs={"device": "cpu", "trust_remote_code": True},
             encode_kwargs={
                 "normalize_embeddings": True,
                 "padding": True,
                 "truncation": True,
-                "max_length": 512
-            }
+                "max_length": 512,
+            },
         )
 
     def generate_embeddings(self, texts: List[str]) -> np.ndarray:

--- a/broom/vector_store.py
+++ b/broom/vector_store.py
@@ -17,7 +17,7 @@ class VectorStore:
         self,
         persist_directory: str = "./data/chroma",
         collection_name: str = "go_code",
-        embedding_model: Optional[Embeddings] = None
+        embedding_model: Optional[Embeddings] = None,
     ):
         """Initialize the vector store.
 
@@ -29,29 +29,26 @@ class VectorStore:
         self.persist_directory = persist_directory
         self.collection_name = collection_name
         self.embedding_model = embedding_model or HuggingFaceEmbeddings(
-            model_name="Salesforce/SFR-Embedding-Code-400M_R",
-            model_kwargs={
-                "device": "cpu",
-                "trust_remote_code": True
-            },
+            model_name="nomic-ai/CodeRankEmbed",
+            model_kwargs={"device": "cpu", "trust_remote_code": True},
             encode_kwargs={
                 "normalize_embeddings": True,
                 "padding": True,
                 "truncation": True,
-                "max_length": 512
-            }
+                "max_length": 512,
+            },
         )
 
         self.db = Chroma(
             persist_directory=persist_directory,
             collection_name=collection_name,
-            embedding_function=self.embedding_model
+            embedding_function=self.embedding_model,
         )
 
     def add_embeddings(
         self,
         embeddings: List[Dict[str, Any]],
-        metadatas: Optional[List[Dict[str, Any]]] = None
+        metadatas: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         """Add embeddings to the vector store.
 
@@ -71,11 +68,7 @@ class VectorStore:
         self.db.add_documents(documents)
         self.db.persist()
 
-    def search(
-        self,
-        query: str,
-        n_results: int = 5
-    ) -> List[Dict[str, Any]]:
+    def search(self, query: str, n_results: int = 5) -> List[Dict[str, Any]]:
         """Search for similar texts.
 
         Args:
@@ -87,14 +80,14 @@ class VectorStore:
         """
         results = self.db.similarity_search_with_score(
             query=query,
-            k=n_results
+            k=n_results,
         )
 
         return [
             {
                 "text": doc.page_content,
                 "metadata": doc.metadata,
-                "score": score
+                "score": score,
             }
             for doc, score in results
         ]


### PR DESCRIPTION
## Summary
- replace SFR-Embedding-Code-400M_R with nomic-ai/CodeRankEmbed in `CodeEmbedder`
- update `VectorStore` default embedding model
- clean up long lines in `VectorStore`

## Testing
- `black --check broom/embeddings.py broom/vector_store.py`
- `flake8 broom/embeddings.py broom/vector_store.py`
- `isort --check broom/embeddings.py broom/vector_store.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tree_sitter')*


------
https://chatgpt.com/codex/tasks/task_e_685d12ad126c832f93c1442c38efa10b